### PR TITLE
Fixed screen blackout bug

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -210,6 +210,13 @@ module.changeToSpace = function(...)
                 break
             end
         end
+
+        -- Tested on macOS Monterey 12.0.1
+        -- Trying to switch to the same space cause a screen blackout
+        if not resetDock and fromID == spaceID then
+            return
+        end
+
         if fromID == 0 then
             error("changeToSpace:unable to identify screen for space id "..spaceID, 2)
         end


### PR DESCRIPTION
Trying to switch to the same space causes a screen blackout on macOS Monterey 12.0.1, caused by lines 237-238. The fix avoids this entirely by checking if the before and after space IDs are the same.