### PR TITLE
Fixes moveWindowToSpace for Monterey 12.2.

### DIFF
--- a/CGSSpace.h
+++ b/CGSSpace.h
@@ -134,6 +134,9 @@ CG_EXTERN void CGSShowSpaces(CGSConnectionID cid, CFArrayRef spaces);
 /// Given an array of space IDs, each space is hidden from the user.
 CG_EXTERN void CGSHideSpaces(CGSConnectionID cid, CFArrayRef spaces);
 
+/// Given an array of window numbers and a space ID, moves each window to the space.
+CG_EXTERN void CGSMoveWindowsToManagedSpace(CGSConnectionID cid, CFArrayRef windows, CGSSpaceID spaceId);
+
 /// Given an array of window numbers and an array of space IDs, adds each window to each space.
 CG_EXTERN void CGSAddWindowsToSpaces(CGSConnectionID cid, CFArrayRef windows, CFArrayRef spaces);
 

--- a/RawAccess.md
+++ b/RawAccess.md
@@ -278,6 +278,13 @@ The `spaces.moveWindowToSpace` wraps this to allow you to specify only one space
 - - -
 
 ~~~lua
+spaces.raw.windowsMoveTo(windowID, spaceID) -> None
+~~~
+Moves the window(s) specified by the windowID (or table of windowIDs) onto the space specified by the spaceID.
+
+- - -
+
+~~~lua
 spaces.raw.windowsOnSpaces(windowID) -> table
 ~~~
 Returns an array of spaces on which any of the windowIDs specified are found on.  `windowID` can be a number or an array of windowIDs.  Note that a space which contains any of the specified windowIDs will be included... it is not possible to determine which windowID caused which spaceID to be included, which is why the wrapped version `spaces.windowOnSpaces` limits you to one windowID.

--- a/init.lua
+++ b/init.lua
@@ -416,8 +416,7 @@ module.moveWindowToSpace = function(...)
             error("moveWindowToSpace:window on multiple spaces", 2)
         end
         if currentSpaces[1] ~= spaceID then
-            internal.windowsAddTo(windowID, spaceID)
-            internal.windowsRemoveFrom(windowID, currentSpaces[1])
+            internal.windowsMoveTo(windowID, spaceID)
         end
         return internal.windowsOnSpaces(windowID)[1]
     else

--- a/internal.m
+++ b/internal.m
@@ -366,6 +366,14 @@ static int removeSpace(lua_State *L) {
     return 0 ;
 }
 
+static int windowsMoveTo(lua_State *L) {
+    LuaSkin *skin = [LuaSkin sharedWithState:L] ;
+    [skin checkArgs:LS_TNUMBER | LS_TTABLE, LS_TNUMBER | LS_TTABLE, LS_TBREAK] ;
+    NSArray *theWindows = getArrayFromNumberOrArray(L, 1) ;
+    CGSMoveWindowsToManagedSpace(CGSDefaultConnection, (__bridge CFArrayRef)theWindows, (CGSSpaceID)lua_tointeger(L, 2));
+    return 0 ;
+}
+
 static int windowsAddTo(lua_State *L) {
     LuaSkin *skin = [LuaSkin sharedWithState:L] ;
     [skin checkArgs:LS_TNUMBER | LS_TTABLE, LS_TNUMBER | LS_TTABLE, LS_TBREAK] ;
@@ -448,6 +456,7 @@ static luaL_Reg moduleLib[] = {
     {"disableUpdates",            disableUpdates},
 
     {"windowsOnSpaces",           windowsOnSpaces},
+    {"windowsMoveTo",             windowsMoveTo},
     {"windowsAddTo",              windowsAddTo},
     {"windowsRemoveFrom",         windowsRemoveFrom},
 


### PR DESCRIPTION
Moving a window between spaces by calling windowsAddTo/windowsRemoveFrom stopped working in 12.2. Added a new windowsMoveTo function which calls CGSMoveWindowsToManagedSpace instead.

Inspired by https://github.com/kasper/phoenix/issues/289 - as noted there, this call has existed at least since High Sierra, so it should work in any version that Hammerspoon supports.